### PR TITLE
Security: Fix credential logging and workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,14 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
     name: Release Provider
+    permissions:
+      contents: write
     steps:
       - id: go-version
         run: echo "::set-output name=version::$(cat ./.go-version)"

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -2,6 +2,8 @@ name: Unit tests
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**.go'
   pull_request:

--- a/ad/internal/gposec/restricted_groups_test.go
+++ b/ad/internal/gposec/restricted_groups_test.go
@@ -147,18 +147,18 @@ func TestRestrictedGroupsSetIniData(t *testing.T) {
 	section := iniFile.Section("Group Membership")
 	gm, err := section.GetKey(fmt.Sprintf("%s__Members", rv.Groups[0].GroupName))
 	if err != nil {
-		t.Errorf(fmt.Sprintf("key group1__Members wasn't found: %s", err))
+		t.Errorf("key group1__Members wasn't found: %s", err)
 	}
 	if gm != nil && gm.Value() != "group2" {
-		t.Errorf(fmt.Sprintf("unexpected value for group1__Members. expected group2 got %s", gm.Value()))
+		t.Errorf("unexpected value for group1__Members. expected group2 got %s", gm.Value())
 	}
 
 	gm, err = section.GetKey(fmt.Sprintf("%s__Memberof", rv.Groups[0].GroupName))
 	if err != nil {
-		t.Errorf(fmt.Sprintf("key group1__Memberof wasn't found: %s", err))
+		t.Errorf("key group1__Memberof wasn't found: %s", err)
 	}
 	if gm != nil && gm.Value() != "group3" {
-		t.Errorf(fmt.Sprintf("unexpected value for group1__Memberof. expected group2 got %s", gm.Value()))
+		t.Errorf("unexpected value for group1__Memberof. expected group2 got %s", gm.Value())
 	}
 
 	iniFile = ini.Empty(loadOpts)

--- a/ad/internal/winrmhelper/powershell_command.go
+++ b/ad/internal/winrmhelper/powershell_command.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-ad/ad/internal/config"
@@ -68,10 +69,7 @@ func NewPSCommand(cmds []string, opts CreatePSCommandOpts) *PSCommand {
 
 	cmd := strings.Join(cmds, " ")
 
-	logStr := cmd
-	if opts.PassCredentials {
-		logStr = strings.ReplaceAll(cmd, opts.Password, "<REDACTED>")
-	}
+	logStr := redactSensitiveData(cmd, opts.Password)
 	log.Printf("[DEBUG] Constructing powerrshell command: %s ", logStr)
 
 	res := PSCommand{
@@ -80,6 +78,36 @@ func NewPSCommand(cmds []string, opts CreatePSCommandOpts) *PSCommand {
 	}
 
 	return &res
+}
+
+// redactSensitiveData redacts passwords and other sensitive data from log output
+func redactSensitiveData(cmd string, winrmPassword string) string {
+	logStr := cmd
+
+	// Redact WinRM password if PassCredentials is enabled
+	if winrmPassword != "" {
+		logStr = strings.ReplaceAll(logStr, winrmPassword, "<REDACTED>")
+	}
+
+	// Redact passwords in -AccountPassword parameter using regex
+	// Matches: -AccountPassword (ConvertTo-SecureString -AsPlainText "password" -Force)
+	accountPasswordRegex := regexp.MustCompile(`-AccountPassword\s+\(ConvertTo-SecureString\s+-AsPlainText\s+"[^"]*"\s+-Force\)`)
+	logStr = accountPasswordRegex.ReplaceAllString(logStr, "-AccountPassword (ConvertTo-SecureString -AsPlainText \"<REDACTED>\" -Force)")
+
+	// Also handle single-quoted passwords
+	accountPasswordRegexSingleQuote := regexp.MustCompile(`-AccountPassword\s+\(ConvertTo-SecureString\s+-AsPlainText\s+'[^']*'\s+-Force\)`)
+	logStr = accountPasswordRegexSingleQuote.ReplaceAllString(logStr, "-AccountPassword (ConvertTo-SecureString -AsPlainText '<REDACTED>' -Force)")
+
+	// Redact passwords in -NewPassword parameter (used by Set-ADAccountPassword)
+	// Matches: -NewPassword (ConvertTo-SecureString -AsPlainText "password" -Force)
+	newPasswordRegex := regexp.MustCompile(`-NewPassword\s+\(ConvertTo-SecureString\s+-AsPlainText\s+"[^"]*"\s+-Force\)`)
+	logStr = newPasswordRegex.ReplaceAllString(logStr, "-NewPassword (ConvertTo-SecureString -AsPlainText \"<REDACTED>\" -Force)")
+
+	// Also handle single-quoted passwords for NewPassword
+	newPasswordRegexSingleQuote := regexp.MustCompile(`-NewPassword\s+\(ConvertTo-SecureString\s+-AsPlainText\s+'[^']*'\s+-Force\)`)
+	logStr = newPasswordRegexSingleQuote.ReplaceAllString(logStr, "-NewPassword (ConvertTo-SecureString -AsPlainText '<REDACTED>' -Force)")
+
+	return logStr
 }
 
 // Run will run a powershell command and return the stdout and stderr
@@ -116,7 +144,10 @@ func (p *PSCommand) Run(conf *config.ProviderConf) (*PSCommandResult, error) {
 
 	log.Printf("[DEBUG] Powershell command exited with code %d", res)
 	if res != 0 {
-		log.Printf("[DEBUG] Stdout: %s, Stderr: %s", stdout, stderr)
+		// Redact sensitive data from stdout/stderr before logging
+		redactedStdout := redactSensitiveData(stdout, p.Password)
+		redactedStderr := redactSensitiveData(stderr, p.Password)
+		log.Printf("[DEBUG] Stdout: %s, Stderr: %s", redactedStdout, redactedStderr)
 	}
 
 	// Decode stderr here for the error to be human readable if we need to return early

--- a/ad/internal/winrmhelper/winrm_user.go
+++ b/ad/internal/winrmhelper/winrm_user.go
@@ -229,7 +229,7 @@ func (u *User) NewUser(conf *config.ProviderConf) (string, error) {
 		return "", err
 	}
 	if result.ExitCode != 0 {
-		log.Printf("[DEBUG] stderr: %s\nstdout: %s", result.StdErr, result.Stdout)
+		// Logging already handled in Run() method with redaction
 		if strings.Contains(result.StdErr, "AlreadyExists") {
 			return "", fmt.Errorf("there is another User named %q", u.PrincipalName)
 		}
@@ -402,7 +402,7 @@ func (u *User) ModifyUser(d *schema.ResourceData, conf *config.ProviderConf) err
 			return err
 		}
 		if result.ExitCode != 0 {
-			log.Printf("[DEBUG] stderr: %s\nstdout: %s", result.StdErr, result.Stdout)
+			// Logging already handled in Run() method with redaction
 			return fmt.Errorf("command Set-ADUser exited with a non-zero exit code %d, stderr: %s", result.ExitCode, result.StdErr)
 		}
 	}
@@ -424,7 +424,7 @@ func (u *User) ModifyUser(d *schema.ResourceData, conf *config.ProviderConf) err
 			return err
 		}
 		if result.ExitCode != 0 {
-			log.Printf("[DEBUG] stderr: %s\nstdout: %s", result.StdErr, result.Stdout)
+			// Logging already handled in Run() method with redaction
 			return fmt.Errorf("command Set-AccountPassword exited with a non-zero exit code %d, stderr: %s", result.ExitCode, result.StdErr)
 		}
 	}
@@ -587,7 +587,7 @@ func GetUserFromHost(conf *config.ProviderConf, guid string, customAttributes []
 	}
 
 	if result.ExitCode != 0 {
-		log.Printf("[DEBUG] stderr: %s\nstdout: %s", result.StdErr, result.Stdout)
+		// Logging already handled in Run() method with redaction
 		return nil, fmt.Errorf("command Get-ADUser exited with a non-zero exit code %d, stderr: %s", result.ExitCode, result.StdErr)
 	}
 


### PR DESCRIPTION
## Summary
- Fixed clear-text password logging vulnerability (go/clear-text-logging)
- Added proper workflow permissions for OpenSSF Scorecard compliance
- Prevented duplicate workflow runs on push+PR events

## Changes
- `ad/internal/winrmhelper/powershell_command.go`: Added redactSensitiveData() function to mask passwords in logs
- `.github/workflows/release.yml`: Added explicit contents: write permission

## Security Impact
**HIGH**: Passwords and credentials are now properly redacted before logging

## Test plan
- [ ] Verify PowerShell commands are logged with redacted passwords
- [ ] Test release workflow permissions