### PR TITLE
fix: correct 'curent os' typo in provider error message

### DIFF
--- a/ad/provider.go
+++ b/ad/provider.go
@@ -24,7 +24,7 @@ func Provider() *schema.Provider {
 					v := val.(string)
 					os := runtime.GOOS
 					if v == "" && os != "windows" {
-						errs = append(errs, fmt.Errorf("%q is allowed to be empty only if terraform runs on windows, (curent os: %q) ", key, os))
+						errs = append(errs, fmt.Errorf("%q is allowed to be empty only if terraform runs on windows, (current os: %q) ", key, os))
 					}
 					return
 				},
@@ -45,7 +45,7 @@ func Provider() *schema.Provider {
 					v := val.(string)
 					os := runtime.GOOS
 					if v == "" && os != "windows" {
-						errs = append(errs, fmt.Errorf("%q is allowed to be empty only if terraform runs on windows, (curent os: %q) ", key, os))
+						errs = append(errs, fmt.Errorf("%q is allowed to be empty only if terraform runs on windows, (current os: %q) ", key, os))
 					}
 					return
 				},


### PR DESCRIPTION
The `winrm_username` and `winrm_password` validators both emit `curent os` instead of `current os`.

Ports the fix from upstream [hashicorp/terraform-provider-ad@14a016ad](https://github.com/hashicorp/terraform-provider-ad/commit/14a016ad119052ba6faad314e2fd255bfa307e20), originally by ngharo. Upstream is archived, so it will not arrive any other way.

Re-authored rather than cherry-picked verbatim so the commit carries a DCO sign-off — sign-off is an authorship declaration, and the original has none.

## Why this instead of merging upstream

This is the **only** upstream change of value. Everything else upstream offers is vendor churn (we unvendored in `2d3067d`), HashiCorp's release CI (we use self-hosted goreleaser), HashiCorp's PR template, or dependency bumps already surpassed by #15.

## Verification

```
go build ./...   rc=0
make test        rc=0
```
`grep 'curent os' ad/provider.go` → 0 occurrences.