### PR TITLE
docs: update fork info for archived upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ What this fork changes on top of upstream:
 - **Unvendors the dependency tree** ([`419b522`](https://github.com/netresearch/terraform-provider-ad/commit/419b5226deda2c227074ca63e28dfbf72986ed72)) and keeps dependencies current, including security updates that upstream stopped receiving.
 - **Releases from our own pipeline** — upstream released through HashiCorp-internal infrastructure that a fork cannot use.
 
-Since upstream is archived, please [file issues here](https://github.com/netresearch/terraform-provider-ad/issues/new/choose) rather than against HashiCorp.
-
 [![Releases](https://img.shields.io/github/release/netresearch/terraform-provider-ad.svg)](https://github.com/netresearch/terraform-provider-ad/releases)
 [![LICENSE](https://img.shields.io/github/license/netresearch/terraform-provider-ad.svg)](https://github.com/netresearch/terraform-provider-ad/blob/main/LICENSE)
 ![Unit tests](https://github.com/netresearch/terraform-provider-ad/workflows/Unit%20tests/badge.svg)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 
 # Terraform Provider for Windows Active Directory (AD)
 
-> ⚠️ **This is a fork of the official [Terraform AD provider](https://github.com/hashicorp/terraform-provider-ad) with fixes**
+> ⚠️ **This is a maintained fork of [hashicorp/terraform-provider-ad](https://github.com/hashicorp/terraform-provider-ad), which HashiCorp has archived.**
+>
+> Upstream is read-only: its last commit was 2025-05-28 and it accepts no further issues or pull requests. This fork continues the provider and is published to the Terraform Registry as [`netresearch/ad`](https://registry.terraform.io/providers/netresearch/ad/latest).
 
-Fixes we've applied: 
-- [Updated the dependencies](https://github.com/netresearch/terraform-provider-ad/commit/419b5226deda2c227074ca63e28dfbf72986ed72)
-- [Fixed UTF-16 issues](https://github.com/hashicorp/terraform-provider-ad/pull/190) by [@sthetz](https://github.com/sthetz)
+What this fork changes on top of upstream:
+
+- **Fixes UTF-16 / unicode encoding issues** — from upstream [PR #190](https://github.com/hashicorp/terraform-provider-ad/pull/190) by [@sthetz](https://github.com/sthetz), which was never merged upstream and, now that the repository is archived, never will be.
+- **Adds `username` to the `ad_user` data source**, equivalent to the `-Name` argument.
+- **Unvendors the dependency tree** ([`419b522`](https://github.com/netresearch/terraform-provider-ad/commit/419b5226deda2c227074ca63e28dfbf72986ed72)) and keeps dependencies current, including security updates that upstream stopped receiving.
+- **Releases from our own pipeline** — upstream released through HashiCorp-internal infrastructure that a fork cannot use.
+
+Since upstream is archived, please [file issues here](https://github.com/netresearch/terraform-provider-ad/issues/new/choose) rather than against HashiCorp.
 
 [![Releases](https://img.shields.io/github/release/netresearch/terraform-provider-ad.svg)](https://github.com/netresearch/terraform-provider-ad/releases)
 [![LICENSE](https://img.shields.io/github/license/netresearch/terraform-provider-ad.svg)](https://github.com/netresearch/terraform-provider-ad/blob/main/LICENSE)
@@ -16,7 +23,7 @@ Fixes we've applied:
 
 This Windows AD provider for Terraform allows you to manage users, groups and group policies in your AD installation.
 
-This provider is a technical preview, which means it's a community supported project. It still requires extensive testing and polishing to mature into a HashiCorp officially supported project. Please [file issues](https://github.com/netresearch/terraform-provider-ad/issues/new/choose) generously and detail your experience while using the provider. We welcome your feedback.
+This provider is community supported. HashiCorp shipped it as a technical preview and has since archived the upstream repository, so it will not become an officially supported HashiCorp project. Please [file issues](https://github.com/netresearch/terraform-provider-ad/issues/new/choose) generously and detail your experience while using the provider. We welcome your feedback.
 
 By using the software in this repository (the AD provider), you acknowledge that:
 * The AD provider is still in development, may change, and has not been released as a commercial product by HashiCorp and is not currently supported in any way by HashiCorp.
@@ -28,7 +35,7 @@ By using the software in this repository (the AD provider), you acknowledge that
 
 * [Terraform](https://www.terraform.io/downloads.html) version 0.12.x+
 * [Windows Server](https://www.microsoft.com/en-us/windows-server) 2012R2 or greater
-* [Go](https://golang.org/doc/install) version 1.16.x+
+* [Go](https://golang.org/doc/install) version 1.25.x+ (only to build from source; see `go.mod`)
 
 ## Getting Started
 


### PR DESCRIPTION
The README's fork section is out of date. It calls upstream "the official Terraform AD provider" and frames this repo as a fork "with fixes" — but HashiCorp **archived** `hashicorp/terraform-provider-ad` (last commit 2025-05-28). Upstream is read-only and takes no further issues or PRs, so this fork is the continuation, not a temporary patch set.

## Changes

- **State that upstream is archived** and read-only, and point at the [`netresearch/ad`](https://registry.terraform.io/providers/netresearch/ad/latest) registry entry.
- **Replace the two-item fixes list** with what the fork actually carries:
  - the UTF-16 fix from upstream [PR #190](https://github.com/hashicorp/terraform-provider-ad/pull/190) — still **open** upstream and, now that the repo is archived, permanently unmergeable
  - the `username` attribute on the `ad_user` data source (absent upstream)
  - the unvendored, actively maintained dependency tree
  - our own release pipeline (upstream released via HashiCorp-internal infrastructure a fork cannot use)
- **Drop** "still requires extensive testing and polishing to mature into a HashiCorp officially supported project" — archiving settled that.
- **Fix the Go requirement**: it said 1.16.x+; `go.mod` requires 1.25.8.

## Verification

Every factual claim checked against the source, not memory:

| Claim | Evidence |
|---|---|
| upstream archived | `archived=true` |
| last upstream commit 2025-05-28 | commits API |
| PR #190 never merged | `state=open merged=false` |
| `username` is ours | present here; **0 occurrences** in `upstream/main:ad/data_source_ad_user.go` |
| registry link live | HTTP 200 |
| `419b522` = unvendor | `chore: unvendor` |

## Left alone

The inherited HashiCorp liability disclaimer ("as-is", "NOT INTENDED FOR PRODUCTION USE", …) is untouched — it's inherited legal text and still accurate; rewriting it isn't a docs call.