### PR TITLE
fix(group_membership): quote members in Add/Remove-ADGroupMember

### DIFF
--- a/ad/internal/winrmhelper/winrm_group_membership.go
+++ b/ad/internal/winrmhelper/winrm_group_membership.go
@@ -63,7 +63,11 @@ func unmarshalGroupMembership(input []byte) ([]*GroupMember, error) {
 func getMembershipList(g []*GroupMember) string {
 	out := []string{}
 	for _, member := range g {
-		out = append(out, member.GUID)
+		// Quote each member: unquoted values containing spaces or commas
+		// (any DN of the form CN=First Last,OU=...) break PowerShell
+		// parameter binding of -Members ("System.Object[]" /
+		// PositionalParameterNotFound).
+		out = append(out, fmt.Sprintf("%q", member.GUID))
 	}
 
 	return strings.Join(out, ",")

--- a/ad/internal/winrmhelper/winrm_group_membership_test.go
+++ b/ad/internal/winrmhelper/winrm_group_membership_test.go
@@ -1,0 +1,20 @@
+package winrmhelper
+
+import "testing"
+
+func TestGetMembershipListQuotesMembers(t *testing.T) {
+	// Members may be sAMAccountNames, SIDs, GUIDs or DNs. DNs contain commas
+	// and often spaces (CN=First Last,OU=...) - unquoted they break the
+	// PowerShell parameter binding of -Members (PositionalParameterNotFound,
+	// "System.Object[]"). Every member must therefore be individually quoted.
+	members := []*GroupMember{
+		{GUID: "annegret.mueller"},
+		{GUID: "CN=Philipp Beck,OU=LSBS,OU=Kunden,DC=netresearch,DC=nr"},
+	}
+
+	got := getMembershipList(members)
+	want := `"annegret.mueller","CN=Philipp Beck,OU=LSBS,OU=Kunden,DC=netresearch,DC=nr"`
+	if got != want {
+		t.Fatalf("getMembershipList() = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
`ad_group_membership` built its PowerShell call as `Add-ADGroupMember -Identity %q -Members %s` with the member list coming from an **unquoted** `strings.Join(out, ",")` in `getMembershipList`. Any member value containing a space or comma — every DN of the form `CN=First Last,OU=...` — therefore broke PowerShell parameter binding (`PositionalParameterNotFound`, `"System.Object[]"`). The resource schema documents SamAccountName, SID, DN and GUID as legal member values, so DNs are a legal input that could not work.

Each member is now individually quoted before joining (`"a","CN=First Last,OU=X"` binds correctly). All three paths go through `getMembershipList` (create at winrm_group_membership.go:168, add/remove via `bulkGroupMembersOp` at :112), so one fix covers them. Unit test included; it fails on the unpatched code.

Observed live 2026-08-05 in netresearch-administration/terraform-ad ([apply job 626779](https://git.netresearch.de/netresearch-administration/terraform-ad/-/jobs/626779), [NRS-4584](https://jira.netresearch.de/browse/NRS-4584)); the consumer repo works around it by passing sAMAccountNames ([terraform-ad MR !36](https://git.netresearch.de/netresearch-administration/terraform-ad/-/merge_requests/36)).
