### PR TITLE
chore: replace upstream hashicorp CODEOWNERS with the org standard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS - Defines code ownership for pull request reviews
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @CybotTM @netresearch/netresearch
+
+# Security-sensitive files require security team review
+/.github/workflows/ @CybotTM @netresearch/sec
+/SECURITY.md @CybotTM @netresearch/sec

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,17 @@
+name: PR Quality Gates
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  quality:
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    with:
+      auto-approve-maintainers: true
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,13 +14,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.go-version'
-      - 'GNUmakefile'
-      - '.github/workflows/unit_tests.yaml'
 
 permissions:
   contents: read

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @hashicorp/terraform-azure


### PR DESCRIPTION
Aligns CODEOWNERS with the estate standard (ofelia's pattern, copied verbatim): default owners `@CybotTM` + `@netresearch/netresearch`, workflows and SECURITY.md additionally `@netresearch/sec`. The previous root-level file was fork residue assigning ownership to `@hashicorp/terraform-azure`, a foreign org's team.

Also adds the org-shared PR quality-gates workflow (`pr-quality.yml`, maintainer auto-approve) that every other Go repo already carries — this repo had no approval source at all, so nothing could satisfy the new 1-approval ruleset.